### PR TITLE
Added a ThenFunc, just to avoid http.HandlerFunc calls.

### DIFF
--- a/chain.go
+++ b/chain.go
@@ -60,6 +60,28 @@ func (c Chain) Then(h http.Handler) http.Handler {
 	return final
 }
 
+// Then chains the middleware and returns the final http.Handler.
+//     New(m1, m2, m3).ThenFunc(h)
+// is equivalent to:
+//     m1(m2(m3(http.HandlerFunc(h))))
+// When the request comes in, it will be passed to m1, then m2, then m3
+// and finally, the given handler
+// (assuming every middleware calls the following one).
+//
+// A chain can be safely reused by calling ThenFunc() several times.
+//     stdStack := alice.New(ratelimitHandler, csrfHandler)
+//     indexPipe = stdStack.ThenFunc(indexHandlerFunc)
+//     authPipe = stdStack.ThenFunc(authHandlerFunc)
+// Note that constructors are called on every call to Then()
+// and thus several instances of the same middleware will be created
+// when a chain is reused in this way.
+// For proper middleware, this should cause no problems.
+//
+// ThenFunc() treats nil as http.DefaultServeMux.
+func (c Chain) ThenFunc(fn http.HandlerFunc) http.Handler {
+	return c.Then(http.HandlerFunc(fn))
+}
+
 // Append extends a chain, adding the specified constructors
 // as the last ones in the request flow.
 //


### PR DESCRIPTION
Thanks for alice =)
After converting a few projects over to using Alice I ended up with quite a few lines like:  

```
chain.Then(http.HandlerFunc(someHandler))
```

I added a helper func, `ThenFunc(http.HandlerFunc)`, to shorten things up a bit:  

```
chain.ThenFunc(someHandler)
```

Just keeps one from creating a wrapper, or always having to create an http.Handler.
