### PR TITLE
possibility to chain a context.Context capable http handler from normal chain

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: go
 
-install: 
+install:
   - go get github.com/stretchr/testify/assert
+  - go get golang.org/x/net/context
 
 go:
   - 1.1

--- a/chain.go
+++ b/chain.go
@@ -72,7 +72,7 @@ func (c Chain) ThenFunc(fn http.HandlerFunc) http.Handler {
 	if fn == nil {
 		return c.Then(nil)
 	}
-	return c.Then(http.HandlerFunc(fn))
+	return c.Then(fn)
 }
 
 // Append extends a chain, adding the specified constructors

--- a/chain.go
+++ b/chain.go
@@ -117,3 +117,11 @@ func (c Chain) Append(constructors ...Constructor) Chain {
 func (c Chain) Extend(chain Chain) Chain {
 	return c.Append(chain.constructors...)
 }
+
+//copy a chain
+func (c Chain) copy() Chain {
+	newCons := make([]Constructor, len(c.constructors))
+	copy(newCons, c.constructors)
+	newC := New(newCons...)
+	return newC
+}

--- a/chain_test.go
+++ b/chain_test.go
@@ -142,3 +142,28 @@ func TestExtendRespectsImmutability(t *testing.T) {
 
 	assert.NotEqual(t, &chain.constructors[0], &newChain.constructors[0])
 }
+
+func TestCopy(t *testing.T) {
+	chain := New(tagMiddleware("t1\n"), tagMiddleware("t2\n"))
+	newChain := chain.copy()
+
+	assert.NotEqual(t, &chain.constructors[0], &newChain.constructors[0])
+	assert.NotEqual(t, &chain, &newChain)
+	assert.NotEqual(t, chain, newChain)
+
+	assert.True(t, len(chain.constructors) == len(newChain.constructors))
+
+	chain.constructors[1] = tagMiddleware(":D")
+
+	chained := newChain.Then(testApp)
+
+	w := httptest.NewRecorder()
+	r, err := http.NewRequest("GET", "/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	chained.ServeHTTP(w, r)
+
+	assert.Equal(t, w.Body.String(), "t1\nt2\napp\n")
+}

--- a/chain_to_context.go
+++ b/chain_to_context.go
@@ -4,30 +4,30 @@ import "net/http"
 
 //ToContextConstructor allows you to chain a non contextualized
 //http handler with a contextualized one.
-type ToContextConstructor func(ContextualizedHandler) http.Handler
+type ToContextConstructor func(ContextualisedHandler) http.Handler
 
-// Contextualize allows you to append a contextualized http handler
+// Contextualise allows you to append a contextualized http handler
 // to your normal chain thus allowing to add ctx support to all
 // subsequent http handlers.
-func (c Chain) Contextualize(transformer ToContextConstructor) (cc toContextualizedChain) {
-	return toContextualizedChain{
+func (c Chain) Contextualise(transformer ToContextConstructor) (cc toContextualisedChain) {
+	return toContextualisedChain{
 		chain:       c.copy(),
 		transformer: transformer,
 	}
 }
 
-// toContextualizedChain acts as a list of non contextualized http.Handlers and then contextualized http.Handlers.
-// toContextualizedChain is effectively immutable:
+// toContextualisedChain acts as a list of non contextualized http.Handlers and then contextualized http.Handlers.
+// toContextualisedChain is effectively immutable:
 // once created, it will always hold
 // the same set of constructors in the same order.
-type toContextualizedChain struct {
+type toContextualisedChain struct {
 	chain       Chain
 	transformer ToContextConstructor
-	cchain      ContextualizedChain
+	cchain      ContextualisedChain
 }
 
-func (tcc toContextualizedChain) Append(constructors ...ContextualizedConstructor) toContextualizedChain {
-	return toContextualizedChain{
+func (tcc toContextualisedChain) Append(constructors ...ContextualisedConstructor) toContextualisedChain {
+	return toContextualisedChain{
 		chain:       tcc.chain.copy(),
 		transformer: tcc.transformer,
 		cchain:      tcc.cchain.Append(constructors...),
@@ -35,7 +35,7 @@ func (tcc toContextualizedChain) Append(constructors ...ContextualizedConstructo
 }
 
 // Then works identically to Chain.Then but with a contextualized handler
-func (tcc toContextualizedChain) Then(cfinal ContextualizedHandler) http.Handler {
+func (tcc toContextualisedChain) Then(cfinal ContextualisedHandler) http.Handler {
 	cfinal = tcc.cchain.Then(cfinal)
 
 	final := tcc.transformer(cfinal)
@@ -43,7 +43,7 @@ func (tcc toContextualizedChain) Then(cfinal ContextualizedHandler) http.Handler
 	return tcc.chain.Then(final)
 }
 
-func (tcc toContextualizedChain) ThenFunc(fn ContextualizedHandlerFunc) http.Handler {
+func (tcc toContextualisedChain) ThenFunc(fn ContextualisedHandlerFunc) http.Handler {
 	if fn == nil {
 		return tcc.Then(nil)
 	}

--- a/chain_to_context.go
+++ b/chain_to_context.go
@@ -1,0 +1,51 @@
+package alice
+
+import "net/http"
+
+//ToContextConstructor allows you to chain a non contextualized
+//http handler with a contextualized one.
+type ToContextConstructor func(ContextualizedHandler) http.Handler
+
+// Contextualize allows you to append a contextualized http handler
+// to your normal chain thus allowing to add ctx support to all
+// subsequent http handlers.
+func (c Chain) Contextualize(transformer ToContextConstructor) (cc toContextualizedChain) {
+	return toContextualizedChain{
+		chain:       c.copy(),
+		transformer: transformer,
+	}
+}
+
+// toContextualizedChain acts as a list of non contextualized http.Handlers and then contextualized http.Handlers.
+// toContextualizedChain is effectively immutable:
+// once created, it will always hold
+// the same set of constructors in the same order.
+type toContextualizedChain struct {
+	chain       Chain
+	transformer ToContextConstructor
+	cchain      ContextualizedChain
+}
+
+func (tcc toContextualizedChain) Append(constructors ...ContextualizedConstructor) toContextualizedChain {
+	return toContextualizedChain{
+		chain:       tcc.chain.copy(),
+		transformer: tcc.transformer,
+		cchain:      tcc.cchain.Append(constructors...),
+	}
+}
+
+// Then works identically to Chain.Then but with a contextualized handler
+func (tcc toContextualizedChain) Then(cfinal ContextualizedHandler) http.Handler {
+	cfinal = tcc.cchain.Then(cfinal)
+
+	final := tcc.transformer(cfinal)
+
+	return tcc.chain.Then(final)
+}
+
+func (tcc toContextualizedChain) ThenFunc(fn ContextualizedHandlerFunc) http.Handler {
+	if fn == nil {
+		return tcc.Then(nil)
+	}
+	return tcc.Then(fn)
+}

--- a/chain_to_context_test.go
+++ b/chain_to_context_test.go
@@ -1,0 +1,75 @@
+package alice
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"golang.org/x/net/context"
+)
+
+// A constructor for middleware
+// that writes its own "tag" into the RW and does nothing else.
+// Useful in checking if a chain is behaving in the right order.
+func ctxTagMiddleware(tag string) ContextualizedConstructor {
+	return func(h ContextualizedHandler) ContextualizedHandler {
+		return ContextualizedHandlerFunc(func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(tag))
+			h.ServeHTTP(ctx, w, r)
+		})
+	}
+}
+
+var ctxTestApp = ContextualizedHandlerFunc(func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+	w.Write([]byte("app\n"))
+})
+
+// Tests creating a new context capable chain
+func TestAppendContext(t *testing.T) {
+	c1 := tagMiddleware("t1\n")
+	c2 := tagMiddleware("t2\n")
+
+	slice := []Constructor{c1, c2}
+
+	chain := New(slice...)
+
+	assert.True(t, funcsEqual(chain.constructors[0], slice[0]))
+	assert.True(t, funcsEqual(chain.constructors[1], slice[1]))
+
+	c2c := func(next ContextualizedHandler) http.Handler {
+		bg := context.Background()
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte("ctx\n"))
+			next.ServeHTTP(bg, w, r)
+		})
+		return nil
+	}
+
+	toCtxchain := chain.Contextualize(c2c)
+
+	assert.True(t, funcsEqual(toCtxchain.transformer, c2c))
+
+	assert.True(t, len(toCtxchain.chain.constructors) != 0)
+
+	assert.True(t, funcsEqual(toCtxchain.chain.constructors[0], slice[0]))
+	assert.True(t, funcsEqual(toCtxchain.chain.constructors[1], slice[1]))
+
+	toCtxchain = toCtxchain.Append(ctxTagMiddleware("ct1\n"), ctxTagMiddleware("ct2\n"))
+
+	assert.True(t, funcsEqual(toCtxchain.chain.constructors[0], slice[0]))
+	assert.True(t, funcsEqual(toCtxchain.chain.constructors[1], slice[1]))
+
+	cchained := toCtxchain.Then(ctxTestApp)
+
+	w := httptest.NewRecorder()
+	r, err := http.NewRequest("GET", "/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cchained.ServeHTTP(w, r)
+
+	assert.Equal(t, w.Body.String(), "t1\nt2\nctx\nct1\nct2\napp\n")
+}

--- a/chain_to_context_test.go
+++ b/chain_to_context_test.go
@@ -13,9 +13,9 @@ import (
 // A constructor for middleware
 // that writes its own "tag" into the RW and does nothing else.
 // Useful in checking if a chain is behaving in the right order.
-func ctxTagMiddleware(tag string) ContextualizedConstructor {
-	return func(h ContextualizedHandler) ContextualizedHandler {
-		return ContextualizedHandlerFunc(func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+func ctxTagMiddleware(tag string) ContextualisedConstructor {
+	return func(h ContextualisedHandler) ContextualisedHandler {
+		return ContextualisedHandlerFunc(func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 			w.Write([]byte(tag))
 			h.ServeHTTPC(ctx, w, r)
 		})
@@ -38,7 +38,7 @@ func TestAppendContext(t *testing.T) {
 	assert.True(t, funcsEqual(chain.constructors[0], slice[0]))
 	assert.True(t, funcsEqual(chain.constructors[1], slice[1]))
 
-	c2c := func(next ContextualizedHandler) http.Handler {
+	c2c := func(next ContextualisedHandler) http.Handler {
 		bg := context.Background()
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Write([]byte("ctx\n"))
@@ -46,7 +46,7 @@ func TestAppendContext(t *testing.T) {
 		})
 	}
 
-	toCtxchain := chain.Contextualize(c2c)
+	toCtxchain := chain.Contextualise(c2c)
 
 	assert.True(t, funcsEqual(toCtxchain.transformer, c2c))
 

--- a/context_chain.go
+++ b/context_chain.go
@@ -6,31 +6,31 @@ import (
 	"golang.org/x/net/context"
 )
 
-//ContextualizedConstructor is a Constructor with a context
-type ContextualizedConstructor func(ContextualizedHandler) ContextualizedHandler
+//ContextualisedConstructor is a Constructor with a context
+type ContextualisedConstructor func(ContextualisedHandler) ContextualisedHandler
 
-//ContextualizedHandler is a http.Handler with a context
-type ContextualizedHandler interface {
+//ContextualisedHandler is a http.Handler with a context
+type ContextualisedHandler interface {
 	ServeHTTPC(context.Context, http.ResponseWriter, *http.Request)
 }
 
-//ContextualizedHandlerFunc is a http.HandlerFunc with a context
-type ContextualizedHandlerFunc func(context.Context, http.ResponseWriter, *http.Request)
+//ContextualisedHandlerFunc is a http.HandlerFunc with a context
+type ContextualisedHandlerFunc func(context.Context, http.ResponseWriter, *http.Request)
 
 //ServeHTTPC is like serve http but with a context
-func (f ContextualizedHandlerFunc) ServeHTTPC(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+func (f ContextualisedHandlerFunc) ServeHTTPC(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 	f(ctx, w, r)
 }
 
-//ContextualizedChain is a chain of contextualised handlers
+//ContextualisedChain is a chain of contextualised handlers
 //it behaves just like Chain
-type ContextualizedChain struct {
-	constructors []ContextualizedConstructor
+type ContextualisedChain struct {
+	constructors []ContextualisedConstructor
 }
 
-//NewContextualized instantiates a new Chain of contextualised http handlers
+//NewContextualised instantiates a new Chain of contextualised http handlers
 //Just like New
-func NewContextualized(constructors ...ContextualizedConstructor) (cc ContextualizedChain) {
+func NewContextualised(constructors ...ContextualisedConstructor) (cc ContextualisedChain) {
 	cc.constructors = append(cc.constructors, constructors...)
 	return
 }
@@ -44,18 +44,18 @@ func NewContextualized(constructors ...ContextualizedConstructor) (cc Contextual
 //     extChain := stdChain.Append(m3, m4)
 //     // requests in stdChain go m1 -> m2
 //     // requests in extChain go m1 -> m2 -> m3 -> m4
-func (cc ContextualizedChain) Append(constructors ...ContextualizedConstructor) ContextualizedChain {
-	newCons := make([]ContextualizedConstructor, len(cc.constructors)+len(constructors))
+func (cc ContextualisedChain) Append(constructors ...ContextualisedConstructor) ContextualisedChain {
+	newCons := make([]ContextualisedConstructor, len(cc.constructors)+len(constructors))
 	copy(newCons, cc.constructors)
 	copy(newCons[len(cc.constructors):], constructors)
 
-	return NewContextualized(newCons...)
+	return NewContextualised(newCons...)
 }
 
 // Then works identically to Chain.Then but with a contextualized handler
-func (cc ContextualizedChain) Then(fn ContextualizedHandler) ContextualizedHandler {
+func (cc ContextualisedChain) Then(fn ContextualisedHandler) ContextualisedHandler {
 	if fn == nil {
-		fn = ContextualizedHandlerFunc(func(_ context.Context, w http.ResponseWriter, r *http.Request) {
+		fn = ContextualisedHandlerFunc(func(_ context.Context, w http.ResponseWriter, r *http.Request) {
 			http.DefaultServeMux.ServeHTTP(w, r)
 		})
 	}
@@ -67,7 +67,7 @@ func (cc ContextualizedChain) Then(fn ContextualizedHandler) ContextualizedHandl
 }
 
 // ThenFunc works identically to Chain.ThenFunc but with a contextualized handler
-func (cc ContextualizedChain) ThenFunc(fn ContextualizedHandlerFunc) ContextualizedHandler {
+func (cc ContextualisedChain) ThenFunc(fn ContextualisedHandlerFunc) ContextualisedHandler {
 	if fn == nil {
 		return cc.Then(nil)
 	}

--- a/context_chain.go
+++ b/context_chain.go
@@ -1,0 +1,69 @@
+package alice
+
+import (
+	"net/http"
+
+	"golang.org/x/net/context"
+)
+
+//ContextualizedConstructor is a Constructor with a context
+type ContextualizedConstructor func(ContextualizedHandler) ContextualizedHandler
+
+//ContextualizedHandler is a http.Handler with a context
+type ContextualizedHandler interface {
+	ServeHTTP(context.Context, http.ResponseWriter, *http.Request)
+}
+
+//ContextualizedHandlerFunc is a http.HandlerFunc with a context
+type ContextualizedHandlerFunc func(context.Context, http.ResponseWriter, *http.Request)
+
+func (f ContextualizedHandlerFunc) ServeHTTP(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+	f(ctx, w, r)
+}
+
+type ContextualizedChain struct {
+	constructors []ContextualizedConstructor
+}
+
+func NewContextualized(constructors ...ContextualizedConstructor) (cc ContextualizedChain) {
+	cc.constructors = append(cc.constructors, constructors...)
+	return
+}
+
+// Append extends a contextualized chain, adding the specified constructors
+// as the last ones in the request flow.
+//
+// Append returns a new chain, leaving the original one untouched.
+//
+//     stdChain := alice.New(m1, m2)
+//     extChain := stdChain.Append(m3, m4)
+//     // requests in stdChain go m1 -> m2
+//     // requests in extChain go m1 -> m2 -> m3 -> m4
+func (c ContextualizedChain) Append(constructors ...ContextualizedConstructor) ContextualizedChain {
+	newCons := make([]ContextualizedConstructor, len(c.constructors)+len(constructors))
+	copy(newCons, c.constructors)
+	copy(newCons[len(c.constructors):], constructors)
+
+	return NewContextualized(newCons...)
+}
+
+// Then works identically to Chain.Then but with a contextualized handler
+func (cc ContextualizedChain) Then(fn ContextualizedHandler) ContextualizedHandler {
+	if fn == nil {
+		fn = ContextualizedHandlerFunc(func(_ context.Context, w http.ResponseWriter, r *http.Request) {
+			http.DefaultServeMux.ServeHTTP(w, r)
+		})
+	}
+
+	for i := len(cc.constructors) - 1; i >= 0; i-- {
+		fn = cc.constructors[i](fn)
+	}
+	return fn
+}
+
+func (cc ContextualizedChain) ThenFunc(fn ContextualizedHandlerFunc) ContextualizedHandler {
+	if fn == nil {
+		return cc.Then(nil)
+	}
+	return cc.Then(fn)
+}


### PR DESCRIPTION
Hello there,
I needed this, so voila :)

It allows you to contextualise an http request.

In my case it's for appengine

1/ create an handler : 
```
package handlers

import (
	"net/http"

	"google.golang.org/appengine"

	"github.com/azr/alice"
)

func AppengineContext(next alice.ContextualizedHandler) http.Handler {
	fn := func(w http.ResponseWriter, r *http.Request) {
		next.ServeHTTPC(appengine.NewContext(r), w, r)
	}

	return http.HandlerFunc(fn)
}
```

2/ now it's contextualisable and I can do

```
commonHandlers.
		Contextualize(handlers.AppengineContext).
		Extend(Auth)
```

Auth beeing something like:
```
func Auth(next alice.ContextualizedHandler) alice.ContextualizedHandler {
	fn := func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
		session, err := auth(ctx, r)
		if err != nil {
			handleSessionErrors(ctx, w, err)
			return
		}
		ctx = context.WithValue(ctx, SessionKey, session)

		next.ServeHTTPC(ctx, w, r)
	}

	return alice.ContextualizedHandlerFunc(fn)
}
```
I hope someday http will handle ctx !