### PR TITLE
Refactor tests to remove dependency 'github.com/stretchr/testify/assert'

### DIFF
--- a/chain_test.go
+++ b/chain_test.go
@@ -32,6 +32,25 @@ var testApp = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte("app\n"))
 })
 
+func TestNew(t *testing.T) {
+	c1 := func(h http.Handler) http.Handler {
+		return nil
+	}
+
+	c2 := func(h http.Handler) http.Handler {
+		return http.StripPrefix("potato", nil)
+	}
+
+	slice := []Constructor{c1, c2}
+
+	chain := New(slice...)
+	for k := range slice {
+		if !funcsEqual(chain.constructors[k], slice[k]) {
+			t.Error("New does not add constructors correctly")
+		}
+	}
+}
+
 func TestThenWorksWithNoMiddleware(t *testing.T) {
 	if !funcsEqual(New().Then(testApp), testApp) {
 		t.Error("Then does not work with no middleware")

--- a/chain_test.go
+++ b/chain_test.go
@@ -6,8 +6,6 @@ import (
 	"net/http/httptest"
 	"reflect"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
 )
 
 // A constructor for middleware
@@ -34,39 +32,22 @@ var testApp = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte("app\n"))
 })
 
-// Tests creating a new chain
-func TestNew(t *testing.T) {
-	c1 := func(h http.Handler) http.Handler {
-		return nil
-	}
-	c2 := func(h http.Handler) http.Handler {
-		return http.StripPrefix("potato", nil)
-	}
-
-	slice := []Constructor{c1, c2}
-
-	chain := New(slice...)
-	assert.True(t, funcsEqual(chain.constructors[0], slice[0]))
-	assert.True(t, funcsEqual(chain.constructors[1], slice[1]))
-}
-
 func TestThenWorksWithNoMiddleware(t *testing.T) {
-	assert.NotPanics(t, func() {
-		chain := New()
-		final := chain.Then(testApp)
-
-		assert.True(t, funcsEqual(final, testApp))
-	})
+	if !funcsEqual(New().Then(testApp), testApp) {
+		t.Error("Then does not work with no middleware")
+	}
 }
 
 func TestThenTreatsNilAsDefaultServeMux(t *testing.T) {
-	chained := New().Then(nil)
-	assert.Equal(t, chained, http.DefaultServeMux)
+	if New().Then(nil) != http.DefaultServeMux {
+		t.Error("Then does not treat nil as DefaultServeMux")
+	}
 }
 
 func TestThenFuncTreatsNilAsDefaultServeMux(t *testing.T) {
-	chained := New().ThenFunc(nil)
-	assert.Equal(t, chained, http.DefaultServeMux)
+	if New().ThenFunc(nil) != http.DefaultServeMux {
+		t.Error("ThenFunc does not treat nil as DefaultServeMux")
+	}
 }
 
 func TestThenFuncConstructsHandlerFunc(t *testing.T) {
@@ -75,11 +56,15 @@ func TestThenFuncConstructsHandlerFunc(t *testing.T) {
 	})
 	chained := New().ThenFunc(fn)
 	rec := httptest.NewRecorder()
+
 	chained.ServeHTTP(rec, (*http.Request)(nil))
-	assert.Equal(t, 200, rec.Code)
+
+	if reflect.TypeOf(chained) != reflect.TypeOf((http.HandlerFunc)(nil)) {
+		t.Error("ThenFunc does not construct HandlerFunc")
+	}
 }
 
-func TestThenOrdersHandlersRight(t *testing.T) {
+func TestThenOrdersHandlersCorrectly(t *testing.T) {
 	t1 := tagMiddleware("t1\n")
 	t2 := tagMiddleware("t2\n")
 	t3 := tagMiddleware("t3\n")
@@ -94,15 +79,21 @@ func TestThenOrdersHandlersRight(t *testing.T) {
 
 	chained.ServeHTTP(w, r)
 
-	assert.Equal(t, w.Body.String(), "t1\nt2\nt3\napp\n")
+	if w.Body.String() != "t1\nt2\nt3\napp\n" {
+		t.Error("Then does not order handlers correctly")
+	}
 }
 
 func TestAppendAddsHandlersCorrectly(t *testing.T) {
 	chain := New(tagMiddleware("t1\n"), tagMiddleware("t2\n"))
 	newChain := chain.Append(tagMiddleware("t3\n"), tagMiddleware("t4\n"))
 
-	assert.Equal(t, len(chain.constructors), 2)
-	assert.Equal(t, len(newChain.constructors), 4)
+	if len(chain.constructors) != 2 {
+		t.Error("chain should have 2 constructors")
+	}
+	if len(newChain.constructors) != 4 {
+		t.Error("newChain should have 4 constructors")
+	}
 
 	chained := newChain.Then(testApp)
 
@@ -114,14 +105,18 @@ func TestAppendAddsHandlersCorrectly(t *testing.T) {
 
 	chained.ServeHTTP(w, r)
 
-	assert.Equal(t, w.Body.String(), "t1\nt2\nt3\nt4\napp\n")
+	if w.Body.String() != "t1\nt2\nt3\nt4\napp\n" {
+		t.Error("Append does not add handlers correctly")
+	}
 }
 
 func TestAppendRespectsImmutability(t *testing.T) {
 	chain := New(tagMiddleware(""))
 	newChain := chain.Append(tagMiddleware(""))
 
-	assert.NotEqual(t, &chain.constructors[0], &newChain.constructors[0])
+	if &chain.constructors[0] == &newChain.constructors[0] {
+		t.Error("Apppend does not respect immutability")
+	}
 }
 
 func TestExtendAddsHandlersCorrectly(t *testing.T) {
@@ -129,9 +124,15 @@ func TestExtendAddsHandlersCorrectly(t *testing.T) {
 	chain2 := New(tagMiddleware("t3\n"), tagMiddleware("t4\n"))
 	newChain := chain1.Extend(chain2)
 
-	assert.Equal(t, len(chain1.constructors), 2)
-	assert.Equal(t, len(chain2.constructors), 2)
-	assert.Equal(t, len(newChain.constructors), 4)
+	if len(chain1.constructors) != 2 {
+		t.Error("chain1 should contain 2 constructors")
+	}
+	if len(chain2.constructors) != 2 {
+		t.Error("chain2 should contain 2 constructors")
+	}
+	if len(newChain.constructors) != 4 {
+		t.Error("newChainshould contain 4 constructors")
+	}
 
 	chained := newChain.Then(testApp)
 
@@ -143,12 +144,16 @@ func TestExtendAddsHandlersCorrectly(t *testing.T) {
 
 	chained.ServeHTTP(w, r)
 
-	assert.Equal(t, w.Body.String(), "t1\nt2\nt3\nt4\napp\n")
+	if w.Body.String() != "t1\nt2\nt3\nt4\napp\n" {
+		t.Error("Extend does not add handlers in correctly")
+	}
 }
 
 func TestExtendRespectsImmutability(t *testing.T) {
 	chain := New(tagMiddleware(""))
 	newChain := chain.Extend(New(tagMiddleware("")))
 
-	assert.NotEqual(t, &chain.constructors[0], &newChain.constructors[0])
+	if &chain.constructors[0] == &newChain.constructors[0] {
+		t.Error("Extend does not respect immutability")
+	}
 }

--- a/chain_test.go
+++ b/chain_test.go
@@ -131,7 +131,7 @@ func TestExtendAddsHandlersCorrectly(t *testing.T) {
 		t.Error("chain2 should contain 2 constructors")
 	}
 	if len(newChain.constructors) != 4 {
-		t.Error("newChainshould contain 4 constructors")
+		t.Error("newChain should contain 4 constructors")
 	}
 
 	chained := newChain.Then(testApp)


### PR DESCRIPTION
To make this package not have to rely on any other third party dependencies, I refactored the tests so that https://github.com/stretchr/testify is no longer necessary and allows Alice to only require the standard library. Is this okay to merge?