### PR TITLE
Added: Endware functionality

### DIFF
--- a/chain.go
+++ b/chain.go
@@ -1,7 +1,9 @@
 // Package alice provides a convenient way to chain http handlers.
 package alice
 
-import "net/http"
+import (
+	"net/http"
+)
 
 // A constructor for a piece of middleware.
 // Some middleware use this constructor out of the box,
@@ -14,6 +16,7 @@ type Constructor func(http.Handler) http.Handler
 // the same set of constructors in the same order.
 type Chain struct {
 	constructors []Constructor
+	endwares     []Endware
 }
 
 // New creates a new chain,
@@ -21,31 +24,41 @@ type Chain struct {
 // New serves no other function,
 // constructors are only called upon a call to Then().
 func New(constructors ...Constructor) Chain {
-	return Chain{append(([]Constructor)(nil), constructors...)}
+	return Chain{append(([]Constructor)(nil), constructors...), nil}
 }
 
-// Then chains the middleware and returns the final http.Handler.
-//     New(m1, m2, m3).Then(h)
+// Then chains the middleware and endwares and returns the final http.Handler.
+//     New(m1, m2, m3).After(e1, e2, e3).Then(h)
 // is equivalent to:
 //     m1(m2(m3(h)))
-// When the request comes in, it will be passed to m1, then m2, then m3
-// and finally, the given handler
-// (assuming every middleware calls the following one).
+// followed by:
+//     e1(e2(e3()))
+// When the request comes in, it will be passed to m1, then m2, then m3,
+// then the given handler (who serves the response), then e1, e2, e3
+// (assuming every middleware/endwares calls the following one).
 //
 // A chain can be safely reused by calling Then() several times.
-//     stdStack := alice.New(ratelimitHandler, csrfHandler)
+//     stdStack := alice.New(ratelimitHandler, csrfHandler).After(loggingHandler)
 //     indexPipe = stdStack.Then(indexHandler)
 //     authPipe = stdStack.Then(authHandler)
-// Note that constructors are called on every call to Then()
-// and thus several instances of the same middleware will be created
+// Note that constructors and endwares are called on every call to Then()
+// and thus several instances of the same middleware/endwares will be created
 // when a chain is reused in this way.
-// For proper middleware, this should cause no problems.
+// For proper middleware/endwares, this should cause no problems.
 //
 // Then() treats nil as http.DefaultServeMux.
 func (c Chain) Then(h http.Handler) http.Handler {
 	if h == nil {
 		h = http.DefaultServeMux
 	}
+
+	h = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h.ServeHTTP(w, r)
+
+		for _, endwareFn := range c.endwares {
+			endwareFn.ServeHTTP(w, r)
+		}
+	})
 
 	for i := range c.constructors {
 		h = c.constructors[len(c.constructors)-1-i](h)
@@ -73,6 +86,7 @@ func (c Chain) ThenFunc(fn http.HandlerFunc) http.Handler {
 // as the last ones in the request flow.
 //
 // Append returns a new chain, leaving the original one untouched.
+// The new chain will have the original chain's endwares.
 //
 //     stdChain := alice.New(m1, m2)
 //     extChain := stdChain.Append(m3, m4)
@@ -83,7 +97,7 @@ func (c Chain) Append(constructors ...Constructor) Chain {
 	newCons = append(newCons, c.constructors...)
 	newCons = append(newCons, constructors...)
 
-	return Chain{newCons}
+	return Chain{newCons, c.endwares}
 }
 
 // Extend extends a chain by adding the specified chain
@@ -92,21 +106,96 @@ func (c Chain) Append(constructors ...Constructor) Chain {
 // Extend returns a new chain, leaving the original one untouched.
 //
 //     stdChain := alice.New(m1, m2)
-//     ext1Chain := alice.New(m3, m4)
+//     ext1Chain := alice.New(m3, m4).After(e1, e2)
 //     ext2Chain := stdChain.Extend(ext1Chain)
-//     // requests in stdChain go  m1 -> m2
-//     // requests in ext1Chain go m3 -> m4
-//     // requests in ext2Chain go m1 -> m2 -> m3 -> m4
+//     // requests in stdChain  go m1 -> m2 -> handler
+//     // requests in ext1Chain go m3 -> m4 -> handler -> e1 -> e2
+//     // requests in ext2Chain go m1 -> m2 -> m3 -> m4 -> handler -> e1 -> e2
 //
 // Another example:
 //  aHtmlAfterNosurf := alice.New(m2)
+//  logRequestChain := aHtmlAfterNosurf.After(e1)
 // 	aHtml := alice.New(m1, func(h http.Handler) http.Handler {
 // 		csrf := nosurf.New(h)
-// 		csrf.SetFailureHandler(aHtmlAfterNosurf.ThenFunc(csrfFail))
+// 		csrf.SetFailureHandler(logRequestChain.ThenFunc(csrfFail))
 // 		return csrf
-// 	}).Extend(aHtmlAfterNosurf)
-//		// requests to aHtml hitting nosurfs success handler go m1 -> nosurf -> m2 -> target-handler
-//		// requests to aHtml hitting nosurfs failure handler go m1 -> nosurf -> m2 -> csrfFail
+// 	}).Extend(logRequestChain)
+//		// requests to aHtml hitting nosurfs success handler go:
+//				m1 -> nosurf -> m2 -> target-handler -> e1
+//		// requests to aHtml hitting nosurfs failure handler go:
+//				m1 -> nosurf -> m2 -> csrfFail -> e1
 func (c Chain) Extend(chain Chain) Chain {
-	return c.Append(chain.constructors...)
+	newC := c.
+		Append(chain.constructors...).
+		AppendEndware(chain.endwares...)
+	return newC
+}
+
+// Endware is functionality executed after a the main handler is called
+// and response has been sent to the requester.  Like middleware,
+// values from the request or response can be accessed. This will not
+// let you access values from the request or the response that can no longer be used.
+// e.g. re-reading a request body, re-setting the response headers, etc.
+type Endware http.Handler
+
+// After creates a new chain with the original chain's
+// constructors and endwares, as well as the provided endwares.
+// Endwares are executed after both the constructors and
+// the Then() handler are called.
+func (c Chain) After(endwares ...Endware) Chain {
+	return Chain{c.constructors, c.endwares}.AppendEndware(endwares...)
+}
+
+// AfterFuncs works identically to After, but takes HandlerFuncs
+// instead of Endwares.
+//
+// The following two statements are equivalent:
+//     c.After(http.HandlerFunc(fn1), http.HandlerFunc(fn2))
+//     c.AfterFuncs(fn1, fn2)
+//
+// AfterFuncs provides all the guarantees of After.
+func (c Chain) AfterFuncs(fns ...func(w http.ResponseWriter, r *http.Request)) Chain {
+	// convert each http.HandlerFunc into an Endware
+	endwares := make([]Endware, len(fns))
+	for i, fn := range fns {
+		endwares[i] = http.HandlerFunc(fn)
+	}
+
+	return Chain{c.constructors, c.endwares}.AppendEndware(endwares...)
+}
+
+// AppendEndware extends a chain, adding the specified endwares
+// as the last ones in the request flow.
+//
+// AppendEndware returns a new chain, leaving the original one untouched.
+// The new chain will have the original chain's constructors.
+//
+//     stdChain := alice.New(m1).After(e1, e2)
+//     extChain := stdChain.AppendEndware(e3, e4)
+//     // requests in stdHandler go m1 -> handler -> e1 -> e2
+//     // requests in extHandler go m1 -> handler -> e1 -> e2 -> e3 -> e4
+func (c Chain) AppendEndware(endwares ...Endware) Chain {
+	newEnds := make([]Endware, 0, len(c.endwares)+len(endwares))
+	newEnds = append(newEnds, c.endwares...)
+	newEnds = append(newEnds, endwares...)
+
+	return Chain{c.constructors, newEnds}
+}
+
+// AppendEndwareFuncs works identically to AppendEndware, but takes HandlerFuncs
+// instead of Endwares.
+//
+// The following two statements are equivalent:
+//     c.AppendEndware(http.HandlerFunc(fn1), http.HandlerFunc(fn2))
+//     c.AppendEndwareFuncs(fn1, fn2)
+//
+// AppendEndwareFuncs provides all the guarantees of AppendEndware.
+func (c Chain) AppendEndwareFuncs(fns ...func(w http.ResponseWriter, r *http.Request)) Chain {
+	// convert each http.HandlerFunc into an Endware
+	endwares := make([]Endware, len(fns))
+	for i, fn := range fns {
+		endwares[i] = http.HandlerFunc(fn)
+	}
+
+	return Chain{c.constructors, c.endwares}.AppendEndware(endwares...)
 }

--- a/chain.go
+++ b/chain.go
@@ -125,10 +125,9 @@ func (c Chain) Append(constructors ...Constructor) Chain {
 //		// requests to aHtml hitting nosurfs failure handler go:
 //				m1 -> nosurf -> m2 -> csrfFail -> e1
 func (c Chain) Extend(chain Chain) Chain {
-	newC := c.
+	return c.
 		Append(chain.constructors...).
 		AppendEndware(chain.endwares...)
-	return newC
 }
 
 // Endware is functionality executed after a the main handler is called

--- a/chain.go
+++ b/chain.go
@@ -47,7 +47,7 @@ func (eh endwareHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 // Then chains the middleware and endwares and returns the final http.Handler.
-//     New(m1, m2, m3).After(e1, e2, e3).Then(h)
+//     New(m1, m2, m3).FinishWith(e1, e2, e3).Then(h)
 // is equivalent to:
 //     m1(m2(m3(h)))
 // followed by:
@@ -57,7 +57,7 @@ func (eh endwareHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // (assuming every middleware/endwares calls the following one).
 //
 // A chain can be safely reused by calling Then() several times.
-//     stdStack := alice.New(ratelimitHandler, csrfHandler).After(loggingHandler)
+//     stdStack := alice.New(ratelimitHandler, csrfHandler).FinishWith(loggingHandler)
 //     indexPipe = stdStack.Then(indexHandler)
 //     authPipe = stdStack.Then(authHandler)
 // Note that constructors and endwares are called on every call to Then()
@@ -121,7 +121,7 @@ func (c Chain) Append(constructors ...Constructor) Chain {
 // Extend returns a new chain, leaving the original one untouched.
 //
 //     stdChain := alice.New(m1, m2)
-//     ext1Chain := alice.New(m3, m4).After(e1, e2)
+//     ext1Chain := alice.New(m3, m4).FinishWith(e1, e2)
 //     ext2Chain := stdChain.Extend(ext1Chain)
 //     // requests in stdChain  go m1 -> m2 -> handler
 //     // requests in ext1Chain go m3 -> m4 -> handler -> e1 -> e2
@@ -129,7 +129,7 @@ func (c Chain) Append(constructors ...Constructor) Chain {
 //
 // Another example:
 //  aHtmlAfterNosurf := alice.New(m2)
-//  logRequestChain := aHtmlAfterNosurf.After(e1)
+//  logRequestChain := aHtmlAfterNosurf.FinishWith(e1)
 // 	aHtml := alice.New(m1, func(h http.Handler) http.Handler {
 // 		csrf := nosurf.New(h)
 // 		csrf.SetFailureHandler(logRequestChain.ThenFunc(csrfFail))
@@ -152,11 +152,11 @@ func (c Chain) Extend(chain Chain) Chain {
 // e.g. re-reading a request body, re-setting the response headers, etc.
 type Endware http.Handler
 
-// After creates a new chain with the original chain's
+// FinishWith creates a new chain with the original chain's
 // constructors and endwares, as well as the provided endwares.
 // Endwares are executed after both the constructors and
 // the Then() handler are called.
-func (c Chain) After(endwares ...Endware) Chain {
+func (c Chain) FinishWith(endwares ...Endware) Chain {
 	newEnds := make([]Endware, 0, len(c.endwares)+len(endwares))
 	newEnds = append(newEnds, c.endwares...)
 	newEnds = append(newEnds, endwares...)
@@ -166,22 +166,22 @@ func (c Chain) After(endwares ...Endware) Chain {
 	return newC
 }
 
-// AfterFuncs works identically to After, but takes HandlerFuncs
+// FinishWithFuncs works identically to FinishWith, but takes HandlerFuncs
 // instead of Endwares.
 //
 // The following two statements are equivalent:
-//     c.After(http.HandlerFunc(fn1), http.HandlerFunc(fn2))
-//     c.AfterFuncs(fn1, fn2)
+//     c.FinishWith(http.HandlerFunc(fn1), http.HandlerFunc(fn2))
+//     c.FinishWithFuncs(fn1, fn2)
 //
-// AfterFuncs provides all the guarantees of After.
-func (c Chain) AfterFuncs(fns ...func(w http.ResponseWriter, r *http.Request)) Chain {
+// FinishWithFuncs provides all the guarantees of FinishWith.
+func (c Chain) FinishWithFuncs(fns ...func(w http.ResponseWriter, r *http.Request)) Chain {
 	// convert each http.HandlerFunc into an Endware
 	endwares := make([]Endware, len(fns))
 	for i, fn := range fns {
 		endwares[i] = http.HandlerFunc(fn)
 	}
 
-	return c.After(endwares...)
+	return c.FinishWith(endwares...)
 }
 
 // AppendEndware extends a chain, adding the specified endwares
@@ -190,12 +190,12 @@ func (c Chain) AfterFuncs(fns ...func(w http.ResponseWriter, r *http.Request)) C
 // AppendEndware returns a new chain, leaving the original one untouched.
 // The new chain will have the original chain's constructors.
 //
-//     stdChain := alice.New(m1).After(e1, e2)
+//     stdChain := alice.New(m1).FinishWith(e1, e2)
 //     extChain := stdChain.AppendEndware(e3, e4)
 //     // requests in stdHandler go m1 -> handler -> e1 -> e2
 //     // requests in extHandler go m1 -> handler -> e1 -> e2 -> e3 -> e4
 func (c Chain) AppendEndware(endwares ...Endware) Chain {
-	return New(c.constructors...).After(append(c.endwares, endwares...)...)
+	return New(c.constructors...).FinishWith(append(c.endwares, endwares...)...)
 }
 
 // AppendEndwareFuncs works identically to AppendEndware, but takes HandlerFuncs

--- a/chain_test.go
+++ b/chain_test.go
@@ -68,10 +68,10 @@ func TestAfter(t *testing.T) {
 
 	slice := []Endware{e1, e2}
 
-	chain := New().After(slice...)
+	chain := New().FinishWith(slice...)
 	for k := range slice {
 		if !funcsEqual(chain.endwares[k], slice[k]) {
-			t.Error("After does not add endwares correctly")
+			t.Error("FinishWith does not add endwares correctly")
 		}
 	}
 }
@@ -83,19 +83,19 @@ func TestThenWorksWithNoMiddleware(t *testing.T) {
 }
 
 func TestThenWorksWithNoEndware(t *testing.T) {
-	if !funcsEqual(New().After().Then(testApp), testApp) {
+	if !funcsEqual(New().FinishWith().Then(testApp), testApp) {
 		t.Error("Then does not work with no endware")
 	}
 }
 
 func TestThenTreatsNilAsDefaultServeMux(t *testing.T) {
-	if New().After().Then(nil) != http.DefaultServeMux {
+	if New().FinishWith().Then(nil) != http.DefaultServeMux {
 		t.Error("Then does not treat nil as DefaultServeMux")
 	}
 }
 
 func TestThenFuncTreatsNilAsDefaultServeMux(t *testing.T) {
-	if New().After().ThenFunc(nil) != http.DefaultServeMux {
+	if New().FinishWith().ThenFunc(nil) != http.DefaultServeMux {
 		t.Error("ThenFunc does not treat nil as DefaultServeMux")
 	}
 }
@@ -104,7 +104,7 @@ func TestThenFuncConstructsHandlerFunc(t *testing.T) {
 	fn := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
 	})
-	chained := New().After().ThenFunc(fn)
+	chained := New().FinishWith().ThenFunc(fn)
 	rec := httptest.NewRecorder()
 
 	chained.ServeHTTP(rec, (*http.Request)(nil))
@@ -122,7 +122,7 @@ func TestThenOrdersHandlersCorrectly(t *testing.T) {
 	e2 := tagEndware("e2\n")
 	e3 := tagEndware("e3\n")
 
-	chained := New(t1, t2, t3).After(e1, e2, e3).Then(testApp)
+	chained := New(t1, t2, t3).FinishWith(e1, e2, e3).Then(testApp)
 
 	w := httptest.NewRecorder()
 	r, err := http.NewRequest("GET", "/", nil)
@@ -170,7 +170,7 @@ func TestAppendAddsHandlersCorrectly(t *testing.T) {
 }
 
 func TestAppendEndwareAddsHandlersCorrectly(t *testing.T) {
-	chain := New(tagMiddleware("t1\n")).After(tagEndware("e1\n"), tagEndware("e2\n"))
+	chain := New(tagMiddleware("t1\n")).FinishWith(tagEndware("e1\n"), tagEndware("e2\n"))
 	newChain := chain.AppendEndware(tagEndware("e3\n"), tagEndware("e4\n"))
 
 	if len(chain.constructors) != 1 {
@@ -202,7 +202,7 @@ func TestAppendEndwareAddsHandlersCorrectly(t *testing.T) {
 }
 
 func TestAppendRespectsImmutability(t *testing.T) {
-	chain := New(tagMiddleware("")).After(tagEndware(""))
+	chain := New(tagMiddleware("")).FinishWith(tagEndware(""))
 	newChain := chain.Append(tagMiddleware(""))
 
 	if &chain.constructors[0] == &newChain.constructors[0] {
@@ -215,7 +215,7 @@ func TestAppendRespectsImmutability(t *testing.T) {
 }
 
 func TestAppendEndwareRespectsImmutability(t *testing.T) {
-	chain := New(tagMiddleware("")).After(tagEndware(""))
+	chain := New(tagMiddleware("")).FinishWith(tagEndware(""))
 	newChain := chain.AppendEndware(tagEndware(""))
 
 	if &chain.constructors[0] == &newChain.constructors[0] {
@@ -228,8 +228,8 @@ func TestAppendEndwareRespectsImmutability(t *testing.T) {
 }
 
 func TestExtendsRespectsImmutability(t *testing.T) {
-	chain := New(tagMiddleware("")).After(tagEndware(""))
-	newChain := New(tagMiddleware("")).After(tagEndware(""))
+	chain := New(tagMiddleware("")).FinishWith(tagEndware(""))
+	newChain := New(tagMiddleware("")).FinishWith(tagEndware(""))
 	newChain = chain.Extend(newChain)
 
 	// chain.constructors[0] should have the same functionality as
@@ -254,7 +254,7 @@ func TestExtendsRespectsImmutability(t *testing.T) {
 func TestExtendAddsHandlersCorrectly(t *testing.T) {
 	chain1 := New(tagMiddleware("t1\n"), tagMiddleware("t2\n"))
 	chain2 := New(tagMiddleware("t3\n"), tagMiddleware("t4\n")).
-		After(tagEndware("e1\n"), tagEndware("e2\n"))
+		FinishWith(tagEndware("e1\n"), tagEndware("e2\n"))
 	newChain := chain1.Extend(chain2)
 
 	if len(chain1.constructors) != 2 {
@@ -294,7 +294,7 @@ func TestExtendAddsHandlersCorrectly(t *testing.T) {
 }
 
 func TestExtendRespectsImmutability(t *testing.T) {
-	chain := New(tagMiddleware("")).After(tagEndware(""))
+	chain := New(tagMiddleware("")).FinishWith(tagEndware(""))
 	newChain := chain.Extend(New())
 
 	if &chain.constructors[0] == &newChain.constructors[0] {

--- a/chain_test.go
+++ b/chain_test.go
@@ -58,9 +58,13 @@ func TestNew(t *testing.T) {
 }
 
 func TestAfter(t *testing.T) {
-	e1 := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	e1 := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("e1\n"))
+	})
 
-	e2 := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	e2 := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("e2\n"))
+	})
 
 	slice := []Endware{e1, e2}
 
@@ -85,13 +89,13 @@ func TestThenWorksWithNoEndware(t *testing.T) {
 }
 
 func TestThenTreatsNilAsDefaultServeMux(t *testing.T) {
-	if New().Then(nil) != http.DefaultServeMux {
+	if New().After().Then(nil) != http.DefaultServeMux {
 		t.Error("Then does not treat nil as DefaultServeMux")
 	}
 }
 
 func TestThenFuncTreatsNilAsDefaultServeMux(t *testing.T) {
-	if New().ThenFunc(nil) != http.DefaultServeMux {
+	if New().After().ThenFunc(nil) != http.DefaultServeMux {
 		t.Error("ThenFunc does not treat nil as DefaultServeMux")
 	}
 }
@@ -100,7 +104,7 @@ func TestThenFuncConstructsHandlerFunc(t *testing.T) {
 	fn := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
 	})
-	chained := New().ThenFunc(fn)
+	chained := New().After().ThenFunc(fn)
 	rec := httptest.NewRecorder()
 
 	chained.ServeHTTP(rec, (*http.Request)(nil))
@@ -291,10 +295,10 @@ func TestExtendAddsHandlersCorrectly(t *testing.T) {
 
 func TestExtendRespectsImmutability(t *testing.T) {
 	chain := New(tagMiddleware("")).After(tagEndware(""))
-	newChain := chain.Extend(New(tagMiddleware("")))
+	newChain := chain.Extend(New())
 
 	if &chain.constructors[0] == &newChain.constructors[0] {
-		t.Error("Extend does not respect immutability")
+		t.Error("Extend does not respect immutability for constructors")
 	}
 
 	if &chain.endwares[0] == &newChain.endwares[0] {

--- a/chain_test.go
+++ b/chain_test.go
@@ -225,7 +225,8 @@ func TestAppendEndwareRespectsImmutability(t *testing.T) {
 
 func TestExtendsRespectsImmutability(t *testing.T) {
 	chain := New(tagMiddleware("")).After(tagEndware(""))
-	newChain := chain.Extend(New(tagMiddleware("")))
+	newChain := New(tagMiddleware("")).After(tagEndware(""))
+	newChain = chain.Extend(newChain)
 
 	// chain.constructors[0] should have the same functionality as
 	// newChain.constructors[1], but check both anyways
@@ -238,6 +239,10 @@ func TestExtendsRespectsImmutability(t *testing.T) {
 	}
 
 	if &chain.endwares[0] == &newChain.endwares[0] {
+		t.Error("Extends does not respect endware immutability")
+	}
+
+	if &chain.endwares[0] == &newChain.endwares[1] {
 		t.Error("Extends does not respect endware immutability")
 	}
 }

--- a/chain_test.go
+++ b/chain_test.go
@@ -57,14 +57,9 @@ func TestNew(t *testing.T) {
 	}
 }
 
-func TestAfter(t *testing.T) {
-	e1 := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte("e1\n"))
-	})
-
-	e2 := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte("e2\n"))
-	})
+func TestFinally(t *testing.T) {
+	e1 := tagEndware("e1\n")
+	e2 := tagEndware("e2\n")
 
 	slice := []Endware{e1, e2}
 


### PR DESCRIPTION
For some use cases, the server may want to perform actions after the user's request has been serviced. Examples include:
- logging the request
- performing maintenance on resources
- error handling
- auditing
- metrics
- anything, really 

For these purposes, I have added `Endware` as a solution. `Endware` is a `http.Handler` alias that allows alice users to create "after the fact" middleware in a similar way to how they create regular middleware. `Endware` is executed after all constructors and handlers have been invoked by `Then(h)`/`ThenFunc(h)`. 

Using endware is simple:
```chain := alice.New(m1, m2)```
becomes
```chainWithEndware := alice.New(m1, m2).Finally(e1, e2)```

This leads the flow of 
```chainWithEndware.Then(h)```
to be
```m1 -> m2 -> h -> e1 -> e2```

The `Append()` functionality has been mirrored in `AppendEndware()`, as well as `Extend` being augmented to also extend endware. `AfterFuncs()` and `AppendEndwareFuncs()` are convenience method for those not dealing with `http.Handler`s directly.

This is still a WIP, just wanted to open it so you could take a look at your leisure.

Sorry in advance if this is not the way you are supposed to contribute code