### PR TITLE
PullRequest_AddingPowerSupport_golang-github-justinas-alice

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,50 @@ language: go
 matrix:
   include:
     - go: 1.2.x
+      arch: amd64
     - go: 1.3.x
+      arch: amd64
     - go: 1.4.x
+      arch: amd64
     - go: 1.5.x
+      arch: amd64
+    - go: 1.5.x
+      arch: ppc64le
+    - go: 1.6.x 
+      arch: amd64
     - go: 1.6.x
+      arch: ppc64le
     - go: 1.7.x
+      arch: amd64
+    - go: 1.7.x
+      arch: ppc64le
     - go: 1.8.x
+      arch: amd64
+    - go: 1.8.x
+      arch: ppc64le
     - go: 1.9.x
+      arch: amd64
+    - go: 1.9.x
+      arch: ppc64le
     - go: 1.10.x
+      arch: amd64
+    - go: 1.10.x
+      arch: ppc64le
     - go: 1.11.x
+      arch: amd64
+    - go: 1.11.x
+      arch: ppc64le
     - go: 1.12.x
+      arch: amd64
+    - go: 1.12.x
+      arch: ppc64le
     - go: 1.13.x
+      arch: amd64
+    - go: 1.13.x
+      arch: ppc64le
     - go: tip
+      arch: amd64
+    - go: tip
+      arch: ppc64le
   allow_failures:
     - go: tip


### PR DESCRIPTION
Adding Power support & making the build run for both arch: amd64/ppc64le.

Adding power support ppc64le
This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3.

The go versions: 1.1.x/1.2.x/1.3.x/1.4.x are not supported on Power(arch: ppc64le) and hence have been excluded from the script.
The build is successful for rest all, Please refer the Travis Build@https://travis-ci.com/github/santosh653/alice