### PR TITLE
chore: add comment to avoid others misunderstanding the code

### DIFF
--- a/chain.go
+++ b/chain.go
@@ -63,6 +63,8 @@ func (c Chain) Then(h http.Handler) http.Handler {
 //
 // ThenFunc provides all the guarantees of Then.
 func (c Chain) ThenFunc(fn http.HandlerFunc) http.Handler {
+	// This nil check cannot be removed due to the "nil is not nil"
+	// common mistake in Go.
 	if fn == nil {
 		return c.Then(nil)
 	}

--- a/chain.go
+++ b/chain.go
@@ -63,8 +63,8 @@ func (c Chain) Then(h http.Handler) http.Handler {
 //
 // ThenFunc provides all the guarantees of Then.
 func (c Chain) ThenFunc(fn http.HandlerFunc) http.Handler {
-	// This nil check cannot be removed due to the "nil is not nil"
-	// common mistake in Go.
+	// This nil check cannot be removed due to the "nil is not nil" common mistake in Go.
+	// Required due to: https://stackoverflow.com/questions/33426977/how-to-golang-check-a-variable-is-nil
 	if fn == nil {
 		return c.Then(nil)
 	}


### PR DESCRIPTION
In Go, nil is not always equal to nil.

One friend asked me that alice has a redundant nil check. So I add the comment to avoid others misunderstanding the code.

For the "nil is not nil" issue, please check https://yourbasic.org/golang/gotcha-why-nil-error-not-equal-nil/