### PR TITLE
Reformat sources for Go 1.19+

### DIFF
--- a/chain.go
+++ b/chain.go
@@ -25,17 +25,23 @@ func New(constructors ...Constructor) Chain {
 }
 
 // Then chains the middleware and returns the final http.Handler.
-//     New(m1, m2, m3).Then(h)
+//
+//	New(m1, m2, m3).Then(h)
+//
 // is equivalent to:
-//     m1(m2(m3(h)))
+//
+//	m1(m2(m3(h)))
+//
 // When the request comes in, it will be passed to m1, then m2, then m3
 // and finally, the given handler
 // (assuming every middleware calls the following one).
 //
 // A chain can be safely reused by calling Then() several times.
-//     stdStack := alice.New(ratelimitHandler, csrfHandler)
-//     indexPipe = stdStack.Then(indexHandler)
-//     authPipe = stdStack.Then(authHandler)
+//
+//	stdStack := alice.New(ratelimitHandler, csrfHandler)
+//	indexPipe = stdStack.Then(indexHandler)
+//	authPipe = stdStack.Then(authHandler)
+//
 // Note that constructors are called on every call to Then()
 // and thus several instances of the same middleware will be created
 // when a chain is reused in this way.
@@ -58,8 +64,9 @@ func (c Chain) Then(h http.Handler) http.Handler {
 // a HandlerFunc instead of a Handler.
 //
 // The following two statements are equivalent:
-//     c.Then(http.HandlerFunc(fn))
-//     c.ThenFunc(fn)
+//
+//	c.Then(http.HandlerFunc(fn))
+//	c.ThenFunc(fn)
 //
 // ThenFunc provides all the guarantees of Then.
 func (c Chain) ThenFunc(fn http.HandlerFunc) http.Handler {
@@ -76,10 +83,10 @@ func (c Chain) ThenFunc(fn http.HandlerFunc) http.Handler {
 //
 // Append returns a new chain, leaving the original one untouched.
 //
-//     stdChain := alice.New(m1, m2)
-//     extChain := stdChain.Append(m3, m4)
-//     // requests in stdChain go m1 -> m2
-//     // requests in extChain go m1 -> m2 -> m3 -> m4
+//	stdChain := alice.New(m1, m2)
+//	extChain := stdChain.Append(m3, m4)
+//	// requests in stdChain go m1 -> m2
+//	// requests in extChain go m1 -> m2 -> m3 -> m4
 func (c Chain) Append(constructors ...Constructor) Chain {
 	newCons := make([]Constructor, 0, len(c.constructors)+len(constructors))
 	newCons = append(newCons, c.constructors...)
@@ -93,22 +100,23 @@ func (c Chain) Append(constructors ...Constructor) Chain {
 //
 // Extend returns a new chain, leaving the original one untouched.
 //
-//     stdChain := alice.New(m1, m2)
-//     ext1Chain := alice.New(m3, m4)
-//     ext2Chain := stdChain.Extend(ext1Chain)
-//     // requests in stdChain go  m1 -> m2
-//     // requests in ext1Chain go m3 -> m4
-//     // requests in ext2Chain go m1 -> m2 -> m3 -> m4
+//	stdChain := alice.New(m1, m2)
+//	ext1Chain := alice.New(m3, m4)
+//	ext2Chain := stdChain.Extend(ext1Chain)
+//	// requests in stdChain go  m1 -> m2
+//	// requests in ext1Chain go m3 -> m4
+//	// requests in ext2Chain go m1 -> m2 -> m3 -> m4
 //
 // Another example:
-//  aHtmlAfterNosurf := alice.New(m2)
-// 	aHtml := alice.New(m1, func(h http.Handler) http.Handler {
-// 		csrf := nosurf.New(h)
-// 		csrf.SetFailureHandler(aHtmlAfterNosurf.ThenFunc(csrfFail))
-// 		return csrf
-// 	}).Extend(aHtmlAfterNosurf)
-//		// requests to aHtml hitting nosurfs success handler go m1 -> nosurf -> m2 -> target-handler
-//		// requests to aHtml hitting nosurfs failure handler go m1 -> nosurf -> m2 -> csrfFail
+//
+//	aHtmlAfterNosurf := alice.New(m2)
+//	aHtml := alice.New(m1, func(h http.Handler) http.Handler {
+//		csrf := nosurf.New(h)
+//		csrf.SetFailureHandler(aHtmlAfterNosurf.ThenFunc(csrfFail))
+//		return csrf
+//	}).Extend(aHtmlAfterNosurf)
+//	// requests to aHtml hitting nosurfs success handler go m1 -> nosurf -> m2 -> target-handler
+//	// requests to aHtml hitting nosurfs failure handler go m1 -> nosurf -> m2 -> csrfFail
 func (c Chain) Extend(chain Chain) Chain {
 	return c.Append(chain.constructors...)
 }


### PR DESCRIPTION
Fix doc formatting with Go 1.19 gofmt changes.
https://go.dev/doc/go1.19#go-doc

This cleanup will help contributors to submit more improvements.