### PR TITLE
Relax ThenFunc signature to allow any HandlerFunc

### DIFF
--- a/chain.go
+++ b/chain.go
@@ -69,13 +69,12 @@ func (c Chain) Then(h http.Handler) http.Handler {
 //	c.ThenFunc(fn)
 //
 // ThenFunc provides all the guarantees of Then.
-func (c Chain) ThenFunc(fn http.HandlerFunc) http.Handler {
-	// This nil check cannot be removed due to the "nil is not nil" common mistake in Go.
-	// Required due to: https://stackoverflow.com/questions/33426977/how-to-golang-check-a-variable-is-nil
+func (c Chain) ThenFunc(fn func(http.ResponseWriter, *http.Request)) http.Handler {
+	// We want to preserve the special behavior similar to Then(nil)
 	if fn == nil {
 		return c.Then(nil)
 	}
-	return c.Then(fn)
+	return c.Then(http.HandlerFunc(fn))
 }
 
 // Append extends a chain, adding the specified constructors

--- a/chain_test.go
+++ b/chain_test.go
@@ -67,6 +67,9 @@ func TestThenFuncTreatsNilAsDefaultServeMux(t *testing.T) {
 	if New().ThenFunc(nil) != http.DefaultServeMux {
 		t.Error("ThenFunc does not treat nil as DefaultServeMux")
 	}
+	if New().ThenFunc(http.HandlerFunc(nil)) != http.DefaultServeMux {
+		t.Error("ThenFunc does not treat nil as DefaultServeMux")
+	}
 }
 
 func TestThenFuncConstructsHandlerFunc(t *testing.T) {


### PR DESCRIPTION
Relax [`ThenFunc`](https://pkg.go.dev/github.com/justinas/alice#Chain.ThenFunc) signature to allow any `HandlerFunc`-style func (based on the anonymous func type of HandlerFunc) not just those with the [`http.HandlerFunc`](https://pkg.go.dev/net/http/#HandlerFunc) concrete type.
This gives more flexibility to users of the chain API.

While this can be considered a breaking change (the `ThenFunc` signature is not strictly the same), the new signature widens the accepted input values for `ThenFunc`.